### PR TITLE
ES-2356 Add support for arbitrary transport objects

### DIFF
--- a/lib/Client/ClientTracer.php
+++ b/lib/Client/ClientTracer.php
@@ -95,8 +95,14 @@ class ClientTracer implements \LightStepBase\Tracer, LoggerAwareInterface {
             $this->_transport = new Transports\TransportUDP($this->logger());
         } else if ($this->_options['transport'] == 'http_proto') {
             $this->_transport = new Transports\TransportHTTPPROTO($this->logger());
-        } else {
+        } else if ($this->_options['transport'] == 'http_json') {
             $this->_transport = new Transports\TransportHTTPJSON($this->logger());
+        } else if (
+            is_object($this->_options['transport']) &&
+            method_exists($this->_options['transport'], 'ensureConnection') &&
+            method_exists($this->_options['transport'], 'flushReport')
+        ) {
+            $this->_transport = $this->_options['transport'];
         }
 
         // Note: the GUID is not generated until the library is initialized

--- a/test/ClientTracerTest.php
+++ b/test/ClientTracerTest.php
@@ -155,4 +155,15 @@ class ClientTracerTest extends BaseLightStepTest
             $this->assertSame(80, $port);
         }
     }
+
+    public function testCustomTransportFromObject() {
+        $transport = new class {
+            public function ensureConnection() {}
+            public function flushReport() {}
+        };
+
+        $tracer = new ClientTracer(['transport' => $transport]);
+
+        $this->assertSame($transport, $this->readAttribute($tracer, '_transport'));
+    }
 }


### PR DESCRIPTION
## What & Why

This adds support for using arbitrary transport objects that support an `ensureConnection` and `flushReport` method. I've avoided using an interface _for now_ to avoid having too many changes in one go. This is step 1 in allowing us to drop [this class](https://github.com/bigcommerce/bigcommerce/blob/60c07dcbe0fd98f7af293f1059817e79090163e6/app/Infrastructure/Metric/Profiler/Driver/LightStep/ClientTracer.php#L21-L22) in bcapp, using the library version instead.

## Breaking changes

This now requires `http_json` to _actually_ be used to get the JSON HTTP transport. Star-search is already configured to do so, and bcapp doesn't use this version of the `ClientTracer` class anyway. We still need to add support for custom span classes to be able to fully replace the bcapp version.

## Testing

Added a new test that uses an anonymous class to simulate a custom object as a transport:

```
[~/Code/lightstep-tracer-php] (add-arbitrary-transport) $ vendor/bin/phpunit
PHPUnit 4.8.36 by Sebastian Bergmann and contributors.

........................................

Time: 1.21 seconds, Memory: 22.00MB

OK (40 tests, 11421 assertions)
```