### PR TITLE
fix(search): ES-3259 fix exception on star-search reqeusts

### DIFF
--- a/lib/Client/NoOpSpan.php
+++ b/lib/Client/NoOpSpan.php
@@ -12,7 +12,7 @@ class NoOpSpan implements \LightStepBase\Span {
 
     public function setEndUserId($id) {}
 
-    public function tracer() { return LightStep::getInstance(); }
+    public function tracer() { return \LightStep::getInstance(); }
     public function setTag($key, $value) {}
     public function setBaggageItem($key, $value) {}
     public function getBaggageItem($key) {}


### PR DESCRIPTION
Fixes an exception appearing on local star-search after making requests

`{"message":"Class \"LightStepBase\\Client\\LightStep\" not found","context":{"exception":{"class":"Error","message":"Class \"LightStepBase\\Client\\LightStep\" not found","code":0,"`