### PR TITLE
ES-3480 Fix the debug log in the http transport to correctly respect argument types

### DIFF
--- a/lib/Client/Transports/TransportHTTPJSON.php
+++ b/lib/Client/Transports/TransportHTTPJSON.php
@@ -61,7 +61,7 @@ class TransportHTTPJSON {
         $thriftReport = $report->toThrift();
 
         if ($this->_verbose >= 3) {
-            $this->logger->debug('report contents:', $thriftReport);
+            $this->logger->debug('report contents', ['report' => $thriftReport]);
         }
 
         $content = json_encode($thriftReport);


### PR DESCRIPTION
This fixes the debug log (y'know, the tool you want to use when things are going wrong) to respect the fact that PSR loggers require the second argument to log methods to be an array. Additionally this removes a useless trailing colon from the log message--in json mode, this is never useful, and in raw line mode, this doesn't do what the author expected it to do anyway.